### PR TITLE
v0.4.0 – Premarket & Postmarket Scanner with Session Tags

### DIFF
--- a/configs/scanner.yaml
+++ b/configs/scanner.yaml
@@ -2,9 +2,14 @@
 
 premarket:
   start_time: "04:00"      # ET, earliest candles to scan
-  end_time: "09:27"        # ET, cutoff before open
-  cadence_minutes: 5       # how often scanner polls Polygon
+  end_time: "09:50"        # ET, accounts for 15 min delay at open
+  cadence_minutes: 5       # keep 5 min polling
 
+postmarket:
+  start_time: "16:00"      # ET, after regular market close
+  end_time: "20:00"        # ET, last extended hours window
+  cadence_minutes: 5       # same as premarket
+  
 scoring_weights:
   gap_percent: 0.4
   rvol: 0.3

--- a/src/adapters/polygon_adapter.py
+++ b/src/adapters/polygon_adapter.py
@@ -1,42 +1,39 @@
 import os
 import requests
+from dotenv import load_dotenv
+
+load_dotenv()
 
 POLYGON_API_KEY = os.getenv("POLYGON_API_KEY")
 BASE_URL = "https://api.polygon.io"
 
+
 def fetch_snapshots(limit=50):
-    """
-    Fetch a batch of US stock snapshots from Polygon and normalize
-    them for the scanner.
-    """
     if not POLYGON_API_KEY:
         raise RuntimeError("❌ No POLYGON_API_KEY found in environment or .env file")
 
     url = f"{BASE_URL}/v2/snapshot/locale/us/markets/stocks/tickers"
-    params = {"apiKey": POLYGON_API_KEY, "limit": limit}
-    resp = requests.get(url, params=params)
-
-    if resp.status_code == 401:
-        raise RuntimeError("❌ Unauthorized: Check your Polygon API key or subscription tier")
-
-    if resp.status_code != 200:
-        raise RuntimeError(f"❌ Polygon API error {resp.status_code}: {resp.text}")
-
+    resp = requests.get(url, params={"apiKey": POLYGON_API_KEY})
+    resp.raise_for_status()
     data = resp.json()
 
     results = []
-    for item in data.get("tickers", []):
+    for t in data.get("tickers", [])[:limit]:
         results.append({
-            "ticker": item["ticker"],
-            "last_price": item.get("lastTrade", {}).get("p"),
-            "prev_close": item.get("prevDay", {}).get("c"),
-            "todays_change": item.get("todaysChange"),
-            "todays_change_pct": item.get("todaysChangePerc"),
-            "volume": item.get("day", {}).get("v"),
-            # provenance stamps
+            "ticker": t["ticker"],
+            "last_price": t.get("lastTrade", {}).get("p"),
+            "prev_close": t.get("prevDay", {}).get("c"),
+            "todays_change": t.get("todaysChange"),
+            "todays_change_pct": t.get("todaysChangePerc"),
+            "volume": t.get("day", {}).get("v"),
+
+            # --- NEW: timestamps (epoch ms) ---
+            "minute_ts": t.get("min", {}).get("t"),
+            "day_ts": t.get("day", {}).get("t"),
+
             "provider_used": "polygon",
             "delayed_data": 1,
             "latency_minutes": 15,
-            "coverage_note": "full_sip"
+            "coverage_note": "full_sip",
         })
     return results

--- a/src/core/filters.py
+++ b/src/core/filters.py
@@ -1,0 +1,41 @@
+# src/core/filters.py
+
+def is_tradeable(snapshot, cfg, ref_price):
+    """
+    Basic tradeable filter.
+
+    Arguments:
+    - snapshot: dict for a single ticker (with last_price, prev_close, etc.)
+    - cfg: full config dict (scanner.yaml loaded)
+    - ref_price: price to compare against (e.g., premarket high or prev_close)
+
+    Returns:
+    - True if the ticker is considered tradeable
+    - False otherwise
+    """
+
+    try:
+        # Get last known price (fallback to prev_close)
+        price = snapshot.get("last_price") or snapshot.get("prev_close")
+        volume = snapshot.get("volume") or 0
+
+        if not price:
+            return False
+
+        # Example rule: skip penny stocks under $1
+        if price < 1.0:
+            return False
+
+        # Example rule: skip illiquid names with no volume
+        if volume == 0:
+            return False
+
+        # Example rule: if price < reference price by too much, skip
+        if ref_price and price < 0.5 * ref_price:
+            return False
+
+        # If all checks passed → tradeable
+        return True
+
+    except Exception:
+        return False

--- a/src/scanner/scanner.py
+++ b/src/scanner/scanner.py
@@ -10,6 +10,7 @@ import pytz
 from src.adapters.polygon_adapter import fetch_snapshots
 from src.core.scoring import score_snapshots, log_top_movers
 from src.core.output import write_watchlist
+from src.core.filters import is_tradeable
 
 
 # --- Load config ---
@@ -33,15 +34,15 @@ def setup_logger(log_path):
 
 
 # --- Time helpers ---
-def within_premarket_window(cfg):
+def within_window(cfg, section):
     tz = pytz.timezone("America/New_York")
     now = datetime.now(tz)
 
     start = datetime.combine(
-        now.date(), datetime.strptime(cfg["premarket"]["start_time"], "%H:%M").time()
+        now.date(), datetime.strptime(cfg[section]["start_time"], "%H:%M").time()
     )
     end = datetime.combine(
-        now.date(), datetime.strptime(cfg["premarket"]["end_time"], "%H:%M").time()
+        now.date(), datetime.strptime(cfg[section]["end_time"], "%H:%M").time()
     )
 
     start = tz.localize(start)
@@ -50,39 +51,54 @@ def within_premarket_window(cfg):
     return start <= now <= end
 
 
-# --- Main loop ---
+# --- Session loop ---
+def run_session(cfg, logger, section):
+    """
+    Runs one session (premarket or postmarket).
+    Adds [PRE] or [POST] tags in logs.
+    """
+    tag = "[PRE]" if section == "premarket" else "[POST]"
+    cadence = int(cfg[section]["cadence_minutes"])
+    logger.info(f"{tag} 📈 Starting {section} scanner loop...")
+
+    while within_window(cfg, section):
+        try:
+            snapshots = fetch_snapshots(limit=50)
+
+            if snapshots:
+                logger.info(
+                    f"{tag} Fetched {len(snapshots)} tickers, "
+                    f"sample: {[s['ticker'] for s in snapshots[:3]]}"
+                )
+                snap_dict = {s["ticker"]: s for s in snapshots if "ticker" in s}
+                scored = score_snapshots(snap_dict)
+                log_top_movers(scored, snap_dict, n=5, tag=tag)
+
+                top5 = scored[:5]
+                write_watchlist(cfg["output"]["watchlist"], top5, cfg["targets"])
+            else:
+                logger.warning(f"{tag} No snapshots returned this cycle")
+
+        except Exception as e:
+            logger.error(f"{tag} ❌ Error during scan tick: {e}", exc_info=True)
+
+        time.sleep(cadence * 60)
+
+    logger.info(f"{tag} ✅ {section.capitalize()} scanner loop finished.")
+
+
 # --- Main loop ---
 def run():
     cfg = load_config()
     logger = setup_logger(cfg["output"]["log"])
 
-    cadence = int(cfg["premarket"]["cadence_minutes"])
-    logger.info("Starting premarket scanner loop...")
+    if within_window(cfg, "premarket"):
+        run_session(cfg, logger, "premarket")
 
-    while within_premarket_window(cfg):
-        try:
-            snapshots = fetch_snapshots(limit=50)
+    if within_window(cfg, "postmarket"):
+        run_session(cfg, logger, "postmarket")
 
-            if snapshots:
-                logger.info(f"Fetched {len(snapshots)} tickers, sample: {[s['ticker'] for s in snapshots[:3]]}")
-                snap_dict = {s["ticker"]: s for s in snapshots if "ticker" in s}
-                scored = score_snapshots(snap_dict)
-                log_top_movers(scored, n=5)
-
-                top5 = scored[:5]
-                write_watchlist(cfg["output"]["watchlist"], top5, cfg["targets"])
-            else:
-                logger.warning("No snapshots returned this cycle")
-
-            # TODO: Add RVOL, ATR stretch
-            # TODO: Validate schema
-
-        except Exception as e:
-            logger.error(f"❌ Error during scan tick: {e}", exc_info=True)
-
-        time.sleep(cadence * 60)
-
-    logger.info("Premarket window closed. Scanner stopped.")
+    logger.info("Scanner fully stopped.")
 
 
 # --- Entrypoint ---
@@ -93,16 +109,18 @@ if __name__ == "__main__":
         snapshots = fetch_snapshots(limit=50)
 
         if snapshots:
-            print("Sample snapshot:", snapshots[0]) # debug
-            logger.info(f"Fetched {len(snapshots)} tickers, sample: {[s['ticker'] for s in snapshots[:3]]}")
+            print("Sample snapshot:", snapshots[0])  # debug
+            logger.info(
+                f"[ONCE] Fetched {len(snapshots)} tickers, "
+                f"sample: {[s['ticker'] for s in snapshots[:3]]}"
+            )
             snap_dict = {s["ticker"]: s for s in snapshots if "ticker" in s}
             scored = score_snapshots(snap_dict)
-            log_top_movers(scored, n=5)
+            log_top_movers(scored, snap_dict, n=5, tag="[ONCE]")
 
             top5 = scored[:5]
             write_watchlist(cfg["output"]["watchlist"], top5, cfg["targets"])
         else:
-            logger.warning("No snapshots returned")
+            logger.warning("[ONCE] No snapshots returned")
     else:
         run()
-


### PR DESCRIPTION
This release introduces major improvements to the stock scanner for both premarket and postmarket sessions, better handling of delayed data, and more transparent logging.

### New Features
- **Postmarket scanning** (16:00–20:00 ET) added in addition to premarket.
- **Session tags** (`[PRE]`, `[POST]`, `[ONCE]`) now included in logs for clarity.
- **Tradeable filter** (`src/core/filters.py`) introduced as a foundation for more robust filtering.

### Changes
- Premarket cutoff adjusted to **09:50 ET** to account for Polygon’s ~15 min delayed data.
- Top movers logs now include:
  - Ticker
  - Price
  - % move
  - Polygon timestamp (actual time of move)
- Refactored `scanner.py` with reusable `run_session()` to handle multiple sessions.

### Fixes
- Restored and cleaned up `log_top_movers()` in `scoring.py`.
- Resolved import errors and ensured stable logging + output writing.